### PR TITLE
fix movement of buttons

### DIFF
--- a/components/bpmn-q/modeler-component/editor/resources/styling/editor-ui.css
+++ b/components/bpmn-q/modeler-component/editor/resources/styling/editor-ui.css
@@ -13,7 +13,6 @@
     color: #636363;
 }
 
-.qwm-extensible-btn,
 .qwm-shortcuts {
     right: 0px;
     position: absolute;


### PR DESCRIPTION
#### Short Description
Currently, when one of the buttons (dataflow, qhana, quantme) is clicked they move to the position of the shortcut button.

#### Proposed Changes
<!-- List all changes proposed in this pull request -->

  * remove prefix in css