### PR TITLE
add bpmn constructs to planqk replacement

### DIFF
--- a/components/bpmn-q/modeler-component/editor/shortcut/ShortcutModal.js
+++ b/components/bpmn-q/modeler-component/editor/shortcut/ShortcutModal.js
@@ -73,7 +73,7 @@ export default function ShortcutModal({ onClose }) {
                     </tr>
                     <tr>
                         <td>Replace Tool</td>
-                        <td className="binding">R</td>
+                        <td className="binding"><code>R</code></td>
                     </tr>
                     <tr>
                         <td>Space Tool</td>

--- a/components/bpmn-q/modeler-component/extensions/planqk/PlanQKReplaceMenuProvider.js
+++ b/components/bpmn-q/modeler-component/extensions/planqk/PlanQKReplaceMenuProvider.js
@@ -1,8 +1,8 @@
 import * as planqkReplaceOptions from './PlanQKReplaceOptions';
-import {is} from 'bpmn-js/lib/util/ModelUtil';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
 import * as consts from './utilities/Constants';
-import {createMenuEntries, createMoreOptionsEntryWithReturn} from "../../editor/util/PopupMenuUtilities";
-import {getPluginConfig} from "../../editor/plugin/PluginConfigHandler";
+import { createMenuEntries, createMoreOptionsEntryWithReturn } from "../../editor/util/PopupMenuUtilities";
+import { getPluginConfig } from "../../editor/plugin/PluginConfigHandler";
 import * as planqkConsts from './utilities/Constants';
 import { filter } from 'min-dash';
 import { isDifferentType } from 'bpmn-js/lib/features/popup-menu/util/TypeUtil';
@@ -37,7 +37,7 @@ export default class PlanQKMenuProvider {
     getPopupMenuEntries(element) {
         const self = this;
         return function (entries) {
-
+            
             // do not show entries for extension elements of other plugins
             if (!(element.type.startsWith('bpmn') || element.type.startsWith('planqk'))) {
                 return entries;
@@ -45,7 +45,8 @@ export default class PlanQKMenuProvider {
 
             // add replacement entries for the active service subscription as replacements for a PlanQK service task
             if (is(element, consts.PLANQK_SERVICE_TASK)) {
-                return self.createPlanQKServiceTaskEntries(element, self.activeSubscriptions);
+                let serviceTaskEntries = self.createTaskEntries(element, self.activeSubscriptions);
+                return Object.assign(serviceTaskEntries, entries);
             }
 
             // add replacement entries for the available data pools as replacements for a PlanQK data pool
@@ -84,9 +85,10 @@ export default class PlanQKMenuProvider {
         const replaceElement = this.replaceElement;
         const activeSubscriptions = this.activeSubscriptions;
         const self = this;
-
         let options = self.createPlanQKServiceTaskEntries(element, activeSubscriptions);
-        options = Object.assign(createMenuEntries(element, planqkReplaceOptions.TASK, translate, replaceElement), options);
+        if (element.type !== consts.PLANQK_SERVICE_TASK) {
+            options = Object.assign(createMenuEntries(element, planqkReplaceOptions.TASK, translate, replaceElement), options);
+        }
 
         return {
             ['replace-by-more-planqk-task-options']: createMoreOptionsEntryWithReturn(
@@ -146,7 +148,7 @@ export default class PlanQKMenuProvider {
                 // replace selected element if it is not already a PlanQK service task
                 let newElement;
                 if (element.type !== planqkConsts.PLANQK_SERVICE_TASK) {
-                    newElement = replaceElement(element, {type: planqkConsts.PLANQK_SERVICE_TASK});
+                    newElement = replaceElement(element, { type: planqkConsts.PLANQK_SERVICE_TASK });
                 }
                 let serviceElement = newElement || element;
 
@@ -193,9 +195,9 @@ export default class PlanQKMenuProvider {
         for (let dataPool of dataPools) {
             if (element.businessObject.name !== dataPool.name) {
                 dataPoolEntries['replace-with-' + dataPool.id + ' (2)'] = this.createNewDataPoolEntry(element, dataPool);
-                }
+            }
         }
-       
+
         return dataPoolEntries;
     }
 


### PR DESCRIPTION
#### Short Description
As described in the following [issue](https://github.com/PlanQK/workflow-modeler/issues/56) the replace menu is empty when selecting a planqk service task, thus, it is not possible to change the type of the task again.

#### Proposed Changes
<!-- List all changes proposed in this pull request -->

  * combine the bpmn entries with the new replacement entries