### PR TITLE
Display config of dependency plugins

### DIFF
--- a/components/bpmn-q/modeler-component/editor/plugin/PluginHandler.js
+++ b/components/bpmn-q/modeler-component/editor/plugin/PluginHandler.js
@@ -224,7 +224,7 @@ export function getConfigTabs() {
 
   // load the config tabs of the active plugins into one array
   for (let plugin of getActivePlugins()) {
-    if (plugin.configTabs && checkEnabledStatus(plugin.name)) {
+    if (plugin.configTabs) {
       configTabs = configTabs.concat(plugin.configTabs);
     }
   }


### PR DESCRIPTION
Currently, only the config of the enabled plugins is displayed. Now the config of the dependency plugins should also be included in the config menu.