### PR TITLE
fix policies inside subprocess

### DIFF
--- a/components/bpmn-q/modeler-component/extensions/opentosca/modeling/properties-provider/ServiceTaskPropertiesProvider.js
+++ b/components/bpmn-q/modeler-component/extensions/opentosca/modeling/properties-provider/ServiceTaskPropertiesProvider.js
@@ -159,7 +159,7 @@ function createOpenTOSCAGroup(element, translate) {
  *
  * @param element the OpenTOSCA element
  */
-function OpenTOSCAProps(element) {
+export function OpenTOSCAProps(element) {
   switch (element.type) {
     case consts.CLOUD_DEPLOYMENT_MODEL_POLICY:
       return CloudDeploymentModelPolicyEntries(element);


### PR DESCRIPTION
Currently, when policies are attached to QuantME Task, which is transformed into a subprocess, they are not appropriately attached to corresponding tasks (if moving subprocess, they hang in the air).
